### PR TITLE
Support optional arguments and -h/--help

### DIFF
--- a/id-dash-change-script
+++ b/id-dash-change-script
@@ -1,22 +1,34 @@
 #!/bin/bash
 
+# Either use the default ("xml/*.xml") or the arguments passed on the command line:
+SOURCE=${@:-xml/*.xml}
+
+ME="${0##*/}"
+
+if [ "-h" = "$1" ] || [ "--help" = "$1" ]; then
+  echo "$ME [-h|--help]"
+  echo "$ME [XML_FILE]..."
+  exit 0
+fi
+
+
 while [[ $(grep -oP '^ROOTID *= *["'"'"']?([^"'"'"'\._]*)[\._]' DC-*) ]]; do
   sed -i -r 's/ROOTID *= *["'"'"']?([^"'"'"'\._]*)([\._]([^"'"'"']*))?["'"'"']?/ROOTID=\1-\3/g' DC-*
 done
 sed -i -r 's/^(ROOTID=[^-]+(-[^-]+)+)-+$/\1/g' DC-*
 
-for f in xml/*.xml; do
+for f in $SOURCE; do
   cat $f | tr '\n' '\r' | sed -r -e 's/\b(linkend|arearefs|xml:id|id)[\r\t ]*=[\r\t ]*(["'"'"'])/\1=\2/g' | tr '\r' '\n' > $f.0
   mv $f.0 $f
 done
 
-while [[ $(grep -oP '\b(linkend|arearefs|xml:id|id)=["'"'"']([^"'"'"'\._]*)[\._]' xml/*.xml) ]]; do
-  sed -i -r 's/\b(linkend|arearefs|xml:id|id)=["'"'"']([^"'"'"'\._]*)([\._]([^"'"'"']*))?["'"'"']/\1="\2-\4"/g' xml/*.xml
+while [[ $(grep -oP '\b(linkend|arearefs|xml:id|id)=["'"'"']([^"'"'"'\._]*)[\._]' $SOURCE) ]]; do
+  sed -i -r 's/\b(linkend|arearefs|xml:id|id)=["'"'"']([^"'"'"'\._]*)([\._]([^"'"'"']*))?["'"'"']/\1="\2-\4"/g' $SOURCE
 done
 
-sed -i -r 's/\b(linkend|arearefs|xml:id|id)="-+/\1="/g' xml/*.xml
+sed -i -r 's/\b(linkend|arearefs|xml:id|id)="-+/\1="/g' $SOURCE
 
-sed -i -r 's/-+"/"/g' xml/*.xml
+sed -i -r 's/-+"/"/g' $SOURCE
 
 # remove temp files from sed
 if [[ $(ls xml/sed* 2>/dev/null) ]] || [[ $(ls sed* 2>/dev/null) ]]; then


### PR DESCRIPTION
This PR contains a small change for `id-dash-change-script`:

* An optional argument that contains one or more XML files; if omitted, the default value `xml/*.xml` is used
* Supports `-h`/`--help` option

## Example Usage

```
$ id-dash-change-script xml/docker*.xml
```

## Use case
If you have only specific XML files to fix, this is possible now.